### PR TITLE
Reformat RoR2Application to fix noticable indentation issues

### DIFF
--- a/Assembly-CSharp.Mod.mm/Patches/RoR2Application.cs
+++ b/Assembly-CSharp.Mod.mm/Patches/RoR2Application.cs
@@ -50,10 +50,10 @@ namespace RoR2
 			RoR2Application.instance = this;
 			if (!this.loaded)
 			{
-                hardMaxPlayers = ModLoader.GetMaxPlayers();
-                maxPlayers = ModLoader.GetMaxPlayers();
-                maxLocalPlayers = ModLoader.GetMaxPlayers();
-                this.OnLoad();
+				hardMaxPlayers = ModLoader.GetMaxPlayers();
+				maxPlayers = ModLoader.GetMaxPlayers();
+				maxLocalPlayers = ModLoader.GetMaxPlayers();
+				this.OnLoad();
 				this.loaded = true;
 			}
 		}


### PR DESCRIPTION
There was a mix of tabs and spaces which in a code editor would usually be abstracted out as tabs would map to 4 spaces and vice versa, but github would show tabs as 8 by default thus being noticeable.

Would be worthwhile at some point to set some code standards up and potentially even some CI to enforce it